### PR TITLE
update node to v12, update url.parse syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:12
 RUN apt-get update && apt-get install zip=3.0-11+b1 unzip tar=1.29b-1.1 --yes --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
`url.parse()` is deprecated. Move to the `url.URL` constructor